### PR TITLE
feat: web root page

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,18 +1,45 @@
 import React from "react";
-import { Alert, Container, Row } from "reactstrap";
+import { Alert, Container } from "reactstrap";
 
 import CustomNavbar from "./components/navbar/CustomNavbar";
 import MonsterCard from "./components/monsterCard/MonsterCard";
 
 export default function App() {
-  const monster = {
-    id: 1,
-    name: "Anjanath",
-    type: "Power",
-    regionFound: "Loloska Forest",
-    portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon136.png",
-    eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_140.png"
-  }
+  // We are fetching assets from Kiranico just for the time being. Sorry!
+  const monsters = [
+    {
+      id: 1,
+      name: "Anjanath",
+      type: "Power",
+      regionFound: "Loloska Forest",
+      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon136.png",
+      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_140.png"
+    },
+    {
+      id: 2,
+      name: "Apceros",
+      type: "Power",
+      regionFound: "Alcala Highlands",
+      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon71.png",
+      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_42.png"
+    },
+    {
+      id: 3,
+      name: "Aptonoth",
+      type: "Power",
+      regionFound: "North Kamuna Cape",
+      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon72.png",
+      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_12.png"
+    },
+    {
+      id: 5,
+      name: "Arzuros",
+      type: "Power",
+      regionFound: "Alcala Highlands",
+      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon7.png",
+      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_20.png"
+    }
+  ]
 
   return (
     <div>
@@ -23,9 +50,11 @@ export default function App() {
         </Alert>
       </div>
 
-      <div>
-        <MonsterCard {...monster} />
-      </div>
+      <Container>
+        {
+          monsters.map((monster) => <MonsterCard {...monster} />)
+        }
+      </Container>
     </div>
   );
 }

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,14 +1,31 @@
-import React from 'react';
-import { Alert } from 'reactstrap';
+import React from "react";
+import { Alert, Container, Row } from "reactstrap";
+
+import CustomNavbar from "./components/navbar/CustomNavbar";
+import MonsterCard from "./components/monsterCard/MonsterCard";
 
 export default function App() {
-  console.log('hello')
+  const monster = {
+    id: 1,
+    name: "Anjanath",
+    type: "Power",
+    regionFound: "Loloska Forest",
+    portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon136.png",
+    eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_140.png"
+  }
+
   return (
     <div>
-      <Alert color="success">
-        This is still a work in progress, do not take this too seriously
-      </Alert>
+      <div>
+        <CustomNavbar />
+        <Alert color="warning">
+          This is still a work in progress, do not take this too seriously
+        </Alert>
+      </div>
+
+      <div>
+        <MonsterCard {...monster} />
+      </div>
     </div>
   );
 }
-

--- a/web/__generated__/AppEntry.js
+++ b/web/__generated__/AppEntry.js
@@ -3,6 +3,7 @@
 import 'expo/build/Expo.fx';
 import { activateKeepAwake } from 'expo-keep-awake';
 import registerRootComponent from 'expo/build/launch/registerRootComponent';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 import App from '../App';
 

--- a/web/app.json
+++ b/web/app.json
@@ -3,8 +3,8 @@
     "config": "metro.config.js"
   },
   "expo": {
-    "name": "web",
-    "slug": "web",
+    "name": "mhst2-dex",
+    "slug": "mhst2-dex",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/web/components/monsterCard/MonsterCard.tsx
+++ b/web/components/monsterCard/MonsterCard.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
-import { Card, CardBody, CardImg, CardSubtitle, CardText, CardTitle, Col, Media, Row } from 'reactstrap'
-import { Monster } from '../../domain/Monster'
+import { Card, CardBody, CardSubtitle, CardText, CardTitle, Col, Media, Row } from 'reactstrap'
+import { Monster } from '../../domain'
 
 export default function MonsterCard(props: Monster) {
   return (
-    <div>
-      <Card>
-        <CardImg top width="auto" src={props.portraitURL} alt={`${props.name} portrait image`} />
+      <Card id={props.name}>
         <CardBody>
           <Row>
             <Col>
@@ -15,13 +13,19 @@ export default function MonsterCard(props: Monster) {
               </Media>
             </Col>
             <Col>
-              <CardTitle tag="h5">{props.name}</CardTitle>
-              <CardSubtitle tag="h6" className="mb-2 text-muted">{props.type}</CardSubtitle>
-              <CardText>Found in {props.regionFound} region</CardText>
+              <Row>
+                <Media left href="#">
+                  <Media src={props.portraitURL} alt={`${props.name} portrait image`}/>
+                </Media>
+                <CardTitle tag="h5">{props.name}</CardTitle>
+              </Row>
+              <Row>
+                <CardSubtitle tag="h6" className="mb-2 text-muted">{props.type}</CardSubtitle>
+                <CardText>Found in {props.regionFound} region</CardText>
+              </Row>
             </Col>
           </Row>
         </CardBody>
       </Card>
-    </div>
   )
 }

--- a/web/components/monsterCard/MonsterCard.tsx
+++ b/web/components/monsterCard/MonsterCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Card, CardBody, CardImg, CardSubtitle, CardText, CardTitle, Col, Media, Row } from 'reactstrap'
+import { Monster } from '../../domain/Monster'
+
+export default function MonsterCard(props: Monster) {
+  return (
+    <div>
+      <Card>
+        <CardImg top width="auto" src={props.portraitURL} alt={`${props.name} portrait image`} />
+        <CardBody>
+          <Row>
+            <Col>
+              <Media left href="#">
+                <Media src={props.eggURL} alt={`${props.name} egg design image`} />
+              </Media>
+            </Col>
+            <Col>
+              <CardTitle tag="h5">{props.name}</CardTitle>
+              <CardSubtitle tag="h6" className="mb-2 text-muted">{props.type}</CardSubtitle>
+              <CardText>Found in {props.regionFound} region</CardText>
+            </Col>
+          </Row>
+        </CardBody>
+      </Card>
+    </div>
+  )
+}

--- a/web/components/navbar/CustomNavbar.tsx
+++ b/web/components/navbar/CustomNavbar.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import { Collapse, Nav, Navbar, NavbarBrand, NavbarToggler, NavItem, NavLink } from "reactstrap";
+
+export default function CustomNavbar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = () => setIsOpen(!isOpen)
+
+  return (
+    <div>
+      <Navbar color="light" light expand="md">
+        <NavbarBrand href="/">mhst2-dex</NavbarBrand>
+        <NavbarToggler onClick={toggle} />
+        <Collapse isOpen={isOpen} navbar>
+          <Nav className="mr-auto" navbar>
+            <NavItem>
+              <NavLink href="/">Home</NavLink>
+            </NavItem>
+            <NavItem>
+              <NavLink href="/about">About</NavLink>
+            </NavItem>
+          </Nav>
+        </Collapse>
+      </Navbar>
+    </div>
+  );
+}

--- a/web/domain/Monster.ts
+++ b/web/domain/Monster.ts
@@ -1,0 +1,8 @@
+export type Monster = {
+  id: number,
+  name: string,
+  type: string,
+  regionFound: string
+  portraitURL: string,
+  eggURL: string,
+}

--- a/web/domain/index.ts
+++ b/web/domain/index.ts
@@ -1,0 +1,1 @@
+export { Monster } from './Monster';

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "axios": "^0.21.1",
+        "bootstrap": "^5.0.2",
         "expo": "~42.0.1",
         "expo-status-bar": "~1.0.4",
         "expo-yarn-workspaces": "^1.5.2",
@@ -3035,6 +3036,16 @@
         }
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.14.0.tgz",
@@ -4881,6 +4892,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "node_modules/bootstrap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.9.2"
+      }
     },
     "node_modules/bplist-creator": {
       "version": "0.0.8",
@@ -20404,6 +20427,12 @@
         "schema-utils": "^2.6.5"
       }
     },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
+      "peer": true
+    },
     "@react-native-community/cli": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.14.0.tgz",
@@ -21934,6 +21963,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bootstrap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
+      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
+      "requires": {}
     },
     "bplist-creator": {
       "version": "0.0.8",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "bootstrap": "^5.0.2",
     "expo": "~42.0.1",
     "expo-status-bar": "~1.0.4",
     "expo-yarn-workspaces": "^1.5.2",


### PR DESCRIPTION
#### This PR aims to add:
- Basic, mostly style-less, root page
- `MonsterCard` component to show monster data
- `MonsterCard` list to show all monsters on the main page

#### Current main page layout
![image](https://user-images.githubusercontent.com/7339932/127499860-bbb85d44-57a8-4588-83ac-9dfb3a40a420.png)
