### PR TITLE
feat: search bar

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,45 +1,17 @@
-import React from "react";
+// Dependencies
+import React, { useState } from "react";
 import { Alert, Container } from "reactstrap";
 
+// Local imports
 import CustomNavbar from "./components/navbar/CustomNavbar";
 import MonsterCard from "./components/monsterCard/MonsterCard";
+import SearchBar from "./components/searchbar/SearchBar";
+import monstersData from './support/monsters.json';
 
 export default function App() {
-  // We are fetching assets from Kiranico just for the time being. Sorry!
-  const monsters = [
-    {
-      id: 1,
-      name: "Anjanath",
-      type: "Power",
-      regionFound: "Loloska Forest",
-      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon136.png",
-      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_140.png"
-    },
-    {
-      id: 2,
-      name: "Apceros",
-      type: "Power",
-      regionFound: "Alcala Highlands",
-      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon71.png",
-      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_42.png"
-    },
-    {
-      id: 3,
-      name: "Aptonoth",
-      type: "Power",
-      regionFound: "North Kamuna Cape",
-      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon72.png",
-      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_12.png"
-    },
-    {
-      id: 5,
-      name: "Arzuros",
-      type: "Power",
-      regionFound: "Alcala Highlands",
-      portraitURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon7.png",
-      eggURL: "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_20.png"
-    }
-  ]
+  // State management for monster data
+  const [monsters, _] = useState(monstersData)
+  const [filteredMonsters, setFilteredMonsters] = useState(monsters)
 
   return (
     <div>
@@ -51,8 +23,12 @@ export default function App() {
       </div>
 
       <Container>
+        <SearchBar monsters={monsters} setFilteredMonsters={setFilteredMonsters} />
+      </Container>
+
+      <Container>
         {
-          monsters.map((monster) => <MonsterCard {...monster} />)
+          filteredMonsters.map((monster) => <MonsterCard {...monster} />)
         }
       </Container>
     </div>

--- a/web/components/monsterCard/MonsterCard.tsx
+++ b/web/components/monsterCard/MonsterCard.tsx
@@ -4,7 +4,7 @@ import { Monster } from '../../domain'
 
 export default function MonsterCard(props: Monster) {
   return (
-      <Card id={props.name}>
+      <Card id={props.name} key={props.id}>
         <CardBody>
           <Row>
             <Col>

--- a/web/components/navbar/CustomNavbar.tsx
+++ b/web/components/navbar/CustomNavbar.tsx
@@ -8,7 +8,7 @@ export default function CustomNavbar() {
 
   return (
     <div>
-      <Navbar color="light" light expand="md">
+      <Navbar color="dark" dark expand="md">
         <NavbarBrand href="/">mhst2-dex</NavbarBrand>
         <NavbarToggler onClick={toggle} />
         <Collapse isOpen={isOpen} navbar>

--- a/web/components/searchbar/SearchBar.tsx
+++ b/web/components/searchbar/SearchBar.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Form, Label, Tooltip, Input } from "reactstrap";
+
+import { Monster } from "../../domain";
+
+export default function SearchBar(props: Record<string, any>) {
+  // State management for search tooltip
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const toggle = () => setTooltipOpen(!tooltipOpen);
+
+  return (
+    <Form>
+      <Label for="search">
+        <span style={{ textDecoration: "underline", color: "brown" }} id="searchTooltip"> Search monsties:</span>
+      </Label>
+      <Tooltip placement="right" isOpen={tooltipOpen} target="searchTooltip" toggle={toggle}>
+        You can prepend the "name:"", "type:" or "regionFound:" keys to do advanced searches
+    </Tooltip>
+      <Input type="text" name="search" id="search" placeholder="type a name or advanced search here" onChange={(event) => handleSearch(event, props.monsters, props.setFilteredMonsters)} />
+    </Form>
+  )
+}
+
+function handleSearch(event: any, monsters: Monster[], setter: any): void {
+  const searchValue: string = event.target.value.toLowerCase();
+  const searchData = generateSearchDataFromInput(searchValue);
+
+  const result = monsters.filter((monster) => filterMonster(monster, searchData))
+  console.log(result)
+  setter(result)
+}
+
+function generateSearchDataFromInput(input: string): Record<string, string> {
+  if (!input.includes(":")) {
+    return { name: input }
+  }
+
+  const fields = input.split(',');
+  let data: Record<string, string> = {};
+
+  fields.map(field => {
+    const [key, value] = field.split(":");
+    data[key.trim()] = value?.trim();
+  })
+
+  return data;
+}
+
+function filterMonster(monster: Monster, searchData: Record<string, string>): boolean {
+  const { name, type, region } = searchData;
+
+  if (name === '') {
+    return true;
+  }
+
+  console.log(`${monster.name}: ${monster.regionFound.toLowerCase().includes(region?.toLowerCase())}`)
+  return (
+    (name ? monster.name.toLowerCase().includes(name?.toLowerCase()) : true)
+    && (type ? monster.type.toLowerCase().includes(type?.toLowerCase()) : true)
+    && (region ? monster.regionFound.toLowerCase().includes(region?.toLowerCase()) : true)
+  )
+    ? true : false
+}

--- a/web/components/searchbar/SearchBar.tsx
+++ b/web/components/searchbar/SearchBar.tsx
@@ -53,7 +53,6 @@ function filterMonster(monster: Monster, searchData: Record<string, string>): bo
     return true;
   }
 
-  console.log(`${monster.name}: ${monster.regionFound.toLowerCase().includes(region?.toLowerCase())}`)
   return (
     (name ? monster.name.toLowerCase().includes(name?.toLowerCase()) : true)
     && (type ? monster.type.toLowerCase().includes(type?.toLowerCase()) : true)

--- a/web/support/monsters.json
+++ b/web/support/monsters.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": 1,
+    "name": "Anjanath",
+    "type": "Power",
+    "regionFound": "Loloska Forest",
+    "portraitURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon136.png",
+    "eggURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_140.png"
+  },
+  {
+    "id": 2,
+    "name": "Apceros",
+    "type": "Power",
+    "regionFound": "Alcala Highlands",
+    "portraitURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon71.png",
+    "eggURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_42.png"
+  },
+  {
+    "id": 3,
+    "name": "Aptonoth",
+    "type": "Power",
+    "regionFound": "North Kamuna Cape",
+    "portraitURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon72.png",
+    "eggURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_12.png"
+  },
+  {
+    "id": 4,
+    "name": "Arzuros",
+    "type": "Power",
+    "regionFound": "Alcala Highlands",
+    "portraitURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon7.png",
+    "eggURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_20.png"
+  },
+  {
+    "id": 5,
+    "name": "Ash Kecha Wacha",
+    "type": "Technical",
+    "regionFound": "Lamure Tower Front",
+    "portraitURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/micons/micon15.png",
+    "eggURL": "https://cdn.kiranico.net/file/kiranico/mhstories-web/eggs/buddy_46.png"
+  }
+]


### PR DESCRIPTION
This PR adds a custom search bar for the main page.

The idea is to allow advanced searching by key inputs, such as `name:` and `type:`, but it does not really work correctly with more than one key field... yet.